### PR TITLE
Remove AI model references from documentation

### DIFF
--- a/Data-Science/Automated Financial Data Analysis Workflow.md
+++ b/Data-Science/Automated Financial Data Analysis Workflow.md
@@ -2,7 +2,7 @@
 
 Slide 1: Introduction to Automated Account Analysis This presentation outlines a comprehensive workflow for analyzing financial accounts using artificial intelligence and Python. We'll start with uploading a balance sheet to an AI chatbot, then move through data extraction, formatting, and finally to in-depth analysis using custom Python code.
 
-Slide 2: Uploading the Balance Sheet The first step in our process is uploading a balance sheet or equivalent financial document to an AI chatbot like Claude or ChatGPT. This can typically be done by either pasting the text directly into the chat interface or by describing the document's contents in detail to the AI.
+Slide 2: Uploading the Balance Sheet The first step in our process is uploading a balance sheet or equivalent financial document to an AI chatbot like ChatGPT. This can typically be done by either pasting the text directly into the chat interface or by describing the document's contents in detail to the AI.
 
 Slide 3: Interacting with the AI Chatbot Once the balance sheet is uploaded, we need to instruct the AI to extract the relevant financial data. Here's an example prompt to use:
 
@@ -135,7 +135,7 @@ Slide 16: Additional References
 
 1.  "Financial Statement Analysis" by Martin Fridson and Fernando Alvarez
 2.  "Python for Finance" by Yves Hilpisch
-3.  Anthropic's Claude documentation: [https://www.anthropic.com](https://www.anthropic.com) or OpenAI's ChatGPT documentation: [https://openai.com/chatgpt](https://openai.com/chatgpt)
+3.  OpenAI's ChatGPT documentation: [https://openai.com/chatgpt](https://openai.com/chatgpt)
 4.  pandas documentation: [https://pandas.pydata.org/docs/](https://pandas.pydata.org/docs/)
 5.  matplotlib documentation: [https://matplotlib.org/stable/contents.html](https://matplotlib.org/stable/contents.html)
 

--- a/LLMs-and-GenAI/Building an Interactive Chatbot App with Groqs LLMs and Streamlit in Python.md
+++ b/LLMs-and-GenAI/Building an Interactive Chatbot App with Groqs LLMs and Streamlit in Python.md
@@ -38,7 +38,7 @@ Next, we'll initialize the Groq client and load the desired language model.
 client = Client(api_key="YOUR_GROQ_API_KEY")
 
 # Load the language model
-model = client.model(ModelType.Claude_V1)
+model = client.model(ModelType.LLAMA3_70B_8192)
 ```
 
 Slide 5: Creating a Simple Chatbot Function

--- a/Misc/Data Mesh vs. Data Fabric Comparing Modern Data Architectures.md
+++ b/Misc/Data Mesh vs. Data Fabric Comparing Modern Data Architectures.md
@@ -1101,5 +1101,5 @@ Slide 17: Additional Resources
 *   Federated Query Processing in Data Mesh Environments: [https://arxiv.org/abs/2204.09877](https://arxiv.org/abs/2204.09877)
 *   Event-Driven Data Mesh Implementation Patterns: [https://arxiv.org/abs/2205.11231](https://arxiv.org/abs/2205.11231)
 
-Note: These paper URLs are for illustration purposes as Claude may hallucinate citations. Please verify them independently.
+Note: These paper URLs are for illustration purposes as AI models may hallucinate citations. Please verify them independently.
 

--- a/Python/Kernel Density Estimation in Python.md
+++ b/Python/Kernel Density Estimation in Python.md
@@ -1,4 +1,4 @@
-## Claude-Kernel Density Estimation in Python
+## Kernel Density Estimation in Python
 Slide 1: Introduction to Kernel Density Estimation
 
 Kernel Density Estimation (KDE) is a non-parametric method for estimating the probability density function of a random variable based on a finite data sample. It's a powerful technique used in data analysis and visualization to smooth out the data and reveal underlying patterns.

--- a/Python/Python Web Security Essentials.md
+++ b/Python/Python Web Security Essentials.md
@@ -869,5 +869,5 @@ Slide 14: Additional Resources
 *   Analysis of Authentication Bypass Vulnerabilities in Modern Web Frameworks
     *   [https://arxiv.org/abs/2311.02756](https://arxiv.org/abs/2311.02756)
 
-Note: These are representative examples of the type of papers that would be relevant. As Claude, I should mention that while the format is correct, you should verify the actual URLs as I cannot guarantee their accuracy.
+Note: These are representative examples of the type of papers that would be relevant. The format is correct, but you should verify the actual URLs independently.
 


### PR DESCRIPTION
Removes all self-referential mentions of the AI model from generated markdown content across 5 files. Human names (Claude Shannon, Claude Quitté, Claude Sammut) are preserved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVsZh3bEKSqMAuE6BpL3JA)_